### PR TITLE
cleanup disk cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,6 @@ dmypy.json
 data/
 
 # disk cache from GADMLoaderService
-cache/
+_cache/
 cache.db
 

--- a/tests/geocoding/test_GADMLoader.py
+++ b/tests/geocoding/test_GADMLoader.py
@@ -17,7 +17,7 @@ from unicef_schools_attribute_cleaning.geocoding.GADMLoader import (
 )
 
 logger = logging.getLogger(__name__)
-__tmp_dir: Path = Path(getcwd()).joinpath("tests").joinpath("cache")
+__tmp_dir: Path = Path(getcwd()).joinpath("tests").joinpath("_cache")
 
 logger.info(__tmp_dir)
 __disk_cache: Optional[dc.Cache] = None
@@ -76,6 +76,7 @@ def test_gadm_loader_no_cache():
 def test_geodataframe_converter():
     container = GADMLoaderContainer()
     container.config.set("disk_cache", __disk_cache)
+    assert __disk_cache.get(url) is not None
     service: GADMLoaderService = container.service()
     file: BytesIO = service.fetch_gadm_file(country=countries.get("MCO"))
     geodf: gp.GeoDataFrame = service.gadm_to_geodataframe(file)

--- a/unicef_schools_attribute_cleaning/pandas/dataframe_cleaner.py
+++ b/unicef_schools_attribute_cleaning/pandas/dataframe_cleaner.py
@@ -3,6 +3,7 @@ Pandas dataframe support module
 """
 import logging
 import os
+from pathlib import Path
 from typing import Optional
 
 import pandas as pd
@@ -112,9 +113,9 @@ def _buffer_for_latitude(point: Point) -> (float, Polygon):
 
 
 def _fix_gadm_data(dataframe: DataFrame, country: Country):
-    cache_dir = os.getcwd()
+    cache_dir: Path = Path(os.getcwd()).joinpath("_cache")
     disk_cache = Cache(
-        cache_dir
+        directory=str(cache_dir)
     )  # note: not deleting this resource, to allow cache to persist after script finishes.
     container = GADMLoaderContainer()
     container.config.set("disk_cache", disk_cache)


### PR DESCRIPTION
Put the disk caches into a named directory, _cache, which is excluded by the .gitignore.

* Fixes an issue with disk cache files & subdirectories littering the working directory.