### PR TITLE
Add timeout parameter to requests.get()

### DIFF
--- a/unicef_schools_attribute_cleaning/geocoding/GADMLoader.py
+++ b/unicef_schools_attribute_cleaning/geocoding/GADMLoader.py
@@ -68,7 +68,7 @@ class GADMLoaderService:
             logger.info(f"cache hit for: {url}")
             return self._unzip(cached_file)
         logger.info(f"cache miss: fetching {url}")
-        response = get(url=url)
+        response = get(url=url, timeout=10)
         in_memory_file = BytesIO(response.content)
         self.disk_cache.set(url, in_memory_file)
         return self._unzip(in_memory_file)


### PR DESCRIPTION
- Per https://requests.readthedocs.io/en/master/user/quickstart/#timeouts

GADM.org downloads are currently offline, and I noticed the script was hanging indefinitely.